### PR TITLE
Return the filename the video was actually saved to

### DIFF
--- a/pafy.py
+++ b/pafy.py
@@ -245,6 +245,7 @@ class Stream():
                 sys.stdout.flush()
             if callback:
                 callback(total, *progress_stats)
+        return filetosave
 
 
 class Pafy():


### PR DESCRIPTION
This is useful both when downloading:
- without specifying a filename, so it can be further processed.
- with specifying a filename, as even in this case validation is performed (replacing / with -).

Of course, if you don't care about the filename you just ignore the return.
