### PR TITLE
Fix for ZeroDivisionError in case of quick uploads / chunks

### DIFF
--- a/pafy/pafy.py
+++ b/pafy/pafy.py
@@ -485,7 +485,7 @@ class Stream(object):
             elapsed = time.time() - t0
             bytesdone += len(chunk)
             if elapsed:
-                rate = ((bytesdone - offset) / 1024) / elapsed
+                rate = ((float(bytesdone) - float(offset)) / 1024.0) / elapsed
                 eta = (total - bytesdone) / (rate * 1024)
             else: # Avoid ZeroDivisionError
                 rate = 0


### PR DESCRIPTION
In cases where a specific chunk is run extremely fast (in this case the `elapsed` value was `0.0006380081176757812`), the rounded result of `rate` may end up being 0, resulting in a ZeroDivisionError when calculating the eta.

By using floats to calculate the rate (resulting in float division with decimal points instead of raw integer division) we end up with a non-zero result.