### PR TITLE
Import unquote_plus from urllib in python 2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ stav
 hugovk
 ids1024
 williamroot
+trygveaa

--- a/pafy/backend_internal.py
+++ b/pafy/backend_internal.py
@@ -18,7 +18,8 @@ if sys.version_info[:2] >= (3, 0):
 
 else:
     from urllib2 import build_opener, HTTPError, URLError
-    from urlparse import parse_qs, unquote_plus
+    from urllib import unquote_plus
+    from urlparse import parse_qs
     uni, pyver = unicode, 2
 
 early_py_version = sys.version_info[:2] < (2, 7)


### PR DESCRIPTION
unquote_plus is available from urllib, not urlparse when using python 2.