### PR TITLE
Fix categories parsing

### DIFF
--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -50,7 +50,7 @@ class YtdlPafy(BasePafy):
         self._likes = self._ydl_info['like_count']
         self._dislikes = self._ydl_info['dislike_count']
         self._username = self._ydl_info['uploader_id']
-        self._category = self._ydl_info['categories'][0]
+        self._category = self._ydl_info['categories'][0] if self._ydl_info['categories'] else ''
         self._bigthumb = g.urls['bigthumb'] % self.videoid
         self._bigthumbhd = g.urls['bigthumbhd'] % self.videoid
         self.expiry = time.time() + g.lifespan


### PR DESCRIPTION
Sometimes, parsing of the youtube categories fails in youtube-dl. In
such a case, the 'categories' attribute becomes `None` (see [relevant source code](https://github.com/rg3/youtube-dl/blob/master/youtube_dl/extractor/youtube.py#L1458)).  Here is the corresponding stracktrace:

```
Traceback (most recent call last):
  ...
  File "./download.py", line 48, in download_video
    video = pafy.new("https://www.youtube.com/watch?v={}".format(video_id))
  File "/mnt/libcast2youtube/venv/local/lib/python2.7/site-packages/pafy/pafy.py", line 122, in new
    return Pafy(url, basic, gdata, size, callback, ydl_opts)
  File "/mnt/libcast2youtube/venv/local/lib/python2.7/site-packages/pafy/backend_youtube_dl.py", line 29, in __init__
    super(YtdlPafy, self).__init__(*args, **kwargs)
  File "/mnt/libcast2youtube/venv/local/lib/python2.7/site-packages/pafy/backend_shared.py", line 95, in __init__
    self._fetch_basic()
  File "/mnt/libcast2youtube/venv/local/lib/python2.7/site-packages/pafy/backend_youtube_dl.py", line 53, in _fetch_basic
    self._category = self._ydl_info['categories'][0]
TypeError: 'NoneType' object has no attribute '__getitem__'
```

To prevent pafy from crashing, we need to check the 'categories' value.