### PR TITLE
Recognize playlists with prefix UU

### DIFF
--- a/pafy/playlist.py
+++ b/pafy/playlist.py
@@ -13,8 +13,9 @@ from .pafy import new, get_categoryname, call_gdata, fetch_decode
 
 
 def extract_playlist_id(playlist_url):
-    # Normal playlists start with PL, Mixes start with RD + first video ID
-    idregx = re.compile(r'((?:RD|PL|LL)[-_0-9a-zA-Z]+)$')
+    # Normal playlists start with PL, Mixes start with RD + first video ID,
+    # Liked videos start with LL, Uploads start with UU
+    idregx = re.compile(r'((?:RD|PL|LL|UU)[-_0-9a-zA-Z]+)$')
 
     playlist_id = None
     if idregx.match(playlist_url):


### PR DESCRIPTION
Playlists starting with UU seem to be a list of all uploads of certain a channel. 
Only the RegEx had to be expanded. To verify the change:

    >>> import pafy
    >>> playlist = pafy.get_playlist("https://www.youtube.com/playlist?list=UUpBwMEZcpf_oCWuqHUPLtHw")

Before the change, an exception was thrown:

    ValueError: Unrecognized playlist url: https://www.youtube.com/playlist?list=UUpBwMEZcpf_oCWuqHUPLtHw

This change fixes #158 