### PR TITLE
Touch up regex to add support for favorites playlists.

### DIFF
--- a/pafy/playlist.py
+++ b/pafy/playlist.py
@@ -14,8 +14,9 @@ from .pafy import new, get_categoryname, call_gdata, fetch_decode
 
 def extract_playlist_id(playlist_url):
     # Normal playlists start with PL, Mixes start with RD + first video ID,
-    # Liked videos start with LL, Uploads start with UU
-    idregx = re.compile(r'((?:RD|PL|LL|UU)[-_0-9a-zA-Z]+)$')
+    # Liked videos start with LL, Uploads start with UU,
+    # Favorites lists start with FL
+    idregx = re.compile(r'((?:RD|PL|LL|UU|FL)[-_0-9a-zA-Z]+)$')
 
     playlist_id = None
     if idregx.match(playlist_url):


### PR DESCRIPTION
Looks like get_playlist2 doesn't recognize valid 'favorites' playlist URLs... I tested this regex touch-up on my system and it works just fine.

> Traceback (most recent call last):
>   File "./main.py", line 184, in <module>
>     main()
>   File "./main.py", line 160, in main
>     tag_db.session, media_storage_path, youtube_playlist_urls)
>   File "/home/zeta/repos/projects/myarchive/src/myarchive/modules/youtubelib.py", line 14, in download_youtube_playlists
>     playlist = pafy.get_playlist2(playlist_url=playlist_url)
>   File "/usr/local/lib/python3.5/dist-packages/pafy/playlist.py", line 228, in get_playlist2
>     return Playlist(playlist_url, basic, gdata, size, callback)
>   File "/usr/local/lib/python3.5/dist-packages/pafy/playlist.py", line 139, in __init__
>     raise ValueError(err % playlist_url)
> ValueError: Unrecognized playlist url: https://www.youtube.com/playlist?list=FL1_v2Czbwmu1OEuoX_YoORg