### PR TITLE
Strip newlines from url in extract_video_id()

### DIFF
--- a/pafy/backend_shared.py
+++ b/pafy/backend_shared.py
@@ -30,7 +30,7 @@ dbg = logging.debug
 def extract_video_id(url):
     """ Extract the video id from a url, return video id as str. """
     idregx = re.compile(r'[\w-]{11}$')
-    url = str(url)
+    url = str(url).strip()
 
     if idregx.match(url):
         return url # ID of video


### PR DESCRIPTION
Prevents the return of a YTID with newlines which was unexpected behaviour.