### PR TITLE
make returned objects pickle'able

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dev/
 .pypi
 vi.py
 __pycache__
+*.egg-info
+*.temp
+/build

--- a/pafy/backend_internal.py
+++ b/pafy/backend_internal.py
@@ -49,7 +49,8 @@ class InternPafy(BasePafy):
 
         allinfo = get_video_info(self.videoid, self.callback)
 
-        self.callback("Fetched video info")
+        if self.callback:
+            self.callback("Fetched video info")
 
         def _get_lst(key, default="unknown", dic=allinfo):
             """ Dict get function, returns first index. """
@@ -79,10 +80,12 @@ class InternPafy(BasePafy):
             self.ciphertag = not self.ciphertag
 
         watch_url = g.urls['watchv'] % self.videoid
-        self.callback("Fetching watch page")
+        if self.callback:
+            self.callback("Fetching watch page")
         watchinfo = fetch_decode(watch_url)  # unicode
         dbg("Fetched watch page")
-        self.callback("Fetched watch page")
+        if self.callback:
+            self.callback("Fetched watch page")
         self.age_ver = re.search(r'player-age-gate-content">', watchinfo) is not None
 
         if self.ciphertag:
@@ -338,10 +341,12 @@ def _decodesig(sig, js_url, callback):
     mainfunction = funcmap[js_url]
 
     # fill in function argument with signature
-    callback("Decrypting signature")
+    if callback:
+        callback("Decrypting signature")
     solved = mainfunction([sig])
     dbg("Decrypted sig = %s...", solved[:30])
-    callback("Decrypted signature")
+    if callback:
+        callback("Decrypted signature")
     return solved
 
 
@@ -366,7 +371,8 @@ def fetch_cached(url, callback, encoding=None, dbg_ref="", file_prefix=""):
     else:
         data = fetch_decode(url, "utf8")  # unicode
         dbg("Fetched %s", dbg_ref)
-        callback("Fetched %s" % dbg_ref)
+        if callback:
+            callback("Fetched %s" % dbg_ref)
 
         with open(cached_filename, "w") as f:
             f.write(data)
@@ -425,7 +431,8 @@ def get_js_sm(watchinfo, callback):
 
     if not mainfunc:
         dbg("Fetching javascript")
-        callback("Fetching javascript")
+        if callback:
+            callback("Fetching javascript")
         javascript = fetch_cached(js_url, callback, encoding="utf8",
                                   dbg_ref="javascript", file_prefix="js-")
         mainfunc = _get_mainfunc_from_js(javascript)

--- a/pafy/backend_shared.py
+++ b/pafy/backend_shared.py
@@ -62,7 +62,7 @@ class BasePafy(object):
         self.videoid = extract_video_id(video_url)
         self.watchv_url = g.urls['watchv'] % self.videoid
 
-        self.callback = callback or (lambda x: None)
+        self.callback = callback
         self._have_basic = False
         self._have_gdata = False
 
@@ -116,13 +116,15 @@ class BasePafy(object):
 
     def _get_video_gdata(self, video_id):
         """ Return json string containing video metadata from gdata api. """
-        self.callback("Fetching video gdata")
+        if self.callback:
+            self.callback("Fetching video gdata")
         query = {'part': 'id,snippet,statistics',
                  'maxResults': 1,
                  'id': video_id}
         gdata = call_gdata('videos', query)
         dbg("Fetched video gdata")
-        self.callback("Fetched video gdata")
+        if self.callback:
+            self.callback("Fetched video gdata")
         return gdata
 
 
@@ -564,7 +566,7 @@ class BaseStream(object):
             self._active = False
             return True
 
-    def download(self, filepath="", quiet=False, callback=lambda *x: None,
+    def download(self, filepath="", quiet=False, callback=None,
                  meta=False, remux_audio=False):
         """ Download.  Use quiet=True to supress output. Return filename.
 

--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -40,7 +40,8 @@ class YtdlPafy(BasePafy):
             except youtube_dl.utils.DownloadError as e:
                 raise IOError(str(e).replace('YouTube said', 'Youtube says'))
 
-        self.callback("Fetched video info")
+        if self.callback:
+            self.callback("Fetched video info")
 
         self._title = self._ydl_info['title']
         self._author = self._ydl_info['uploader']

--- a/pafy/playlist.py
+++ b/pafy/playlist.py
@@ -11,7 +11,6 @@ else:
 from . import g
 from .pafy import new, get_categoryname, call_gdata, fetch_decode
 
-
 def extract_playlist_id(playlist_url):
     # Normal playlists start with PL, Mixes start with RD + first video ID,
     # Liked videos start with LL, Uploads start with UU,
@@ -34,7 +33,7 @@ def extract_playlist_id(playlist_url):
 
 
 def get_playlist(playlist_url, basic=False, gdata=False,
-                 size=False, callback=lambda x: None):
+                 size=False, callback=None):
     """ Return a dict containing Pafy objects from a YouTube Playlist.
 
     The returned Pafy objects are initialised using the arguments to
@@ -102,13 +101,15 @@ def get_playlist(playlist_url, basic=False, gdata=False,
                            callback=callback)
 
         except IOError as e:
-            callback("%s: %s" % (v['title'], e.message))
+            if callback:
+                callback("%s: %s" % (v['title'], e.message))
             continue
 
         pafy_obj.populate_from_playlist(vid_data)
         playlist['items'].append(dict(pafy=pafy_obj,
                                       playlist_meta=vid_data))
-        callback("Added video: %s" % v['title'])
+        if callback:
+            callback("Added video: %s" % v['title'])
 
     return playlist
 
@@ -204,12 +205,14 @@ class Playlist(object):
                             size=self._size, callback=self._callback)
 
                 except IOError as e:
-                    self.callback("%s: %s" % (v['title'], e.message))
+                    if self.callback:
+                        self.callback("%s: %s" % (v['title'], e.message))
                     continue
 
                 pafy_obj.populate_from_playlist(vid_data)
                 items.append(pafy_obj)
-                self._callback("Added video: %s" % vid_data['title'])
+                if self._callback:
+                    self._callback("Added video: %s" % vid_data['title'])
                 yield pafy_obj
 
             if not playlistitems.get('nextPageToken'):
@@ -220,7 +223,7 @@ class Playlist(object):
 
 
 def get_playlist2(playlist_url, basic=False, gdata=False,
-                 size=False, callback=lambda x: None):
+                 size=False, callback=None):
     """ Return a Playlist object from a YouTube Playlist.
 
     The returned Pafy objects are initialised using the arguments to

--- a/tests/test.py
+++ b/tests/test.py
@@ -212,6 +212,10 @@ class Test(unittest.TestCase):
             for field in "playlist_id description author title".split():
                 self.assertEqual(fetched[field], pl[field])
 
+    def test_get_playlist_pickle(self):
+        import pickle
+        for pl in Test.playlists:
+            pickle.dumps(pl['fetched'])
 
 PLAYLISTS = [
     {


### PR DESCRIPTION
Don't use lambdas as default arguments for empty callbacks. Instead check for callback at each call.

fixes https://github.com/mps-youtube/pafy/issues/174