### PR TITLE
Fetch best thumbnail for a given video

### DIFF
--- a/pafy/backend_shared.py
+++ b/pafy/backend_shared.py
@@ -411,6 +411,7 @@ class BasePafy(object):
             return response.getcode() < 300
 
     def getbestthumb(self):
+        """ Return the best available thumbnail."""
         if not self._bestthumb:
             part_url = "http://i.ytimg.com/vi/%s/" % self.videoid
             # Thumbnail resolution sorted in descending order

--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -52,6 +52,7 @@ class YtdlPafy(BasePafy):
         self._dislikes = self._ydl_info['dislike_count']
         self._username = self._ydl_info['uploader_id']
         self._category = self._ydl_info['categories'][0] if self._ydl_info['categories'] else ''
+        self._bestthumb = self._ydl_info['thumbnails'][0]['url']
         self._bigthumb = g.urls['bigthumb'] % self.videoid
         self._bigthumbhd = g.urls['bigthumbhd'] % self.videoid
         self.expiry = time.time() + g.lifespan


### PR DESCRIPTION
This PR adds method `Pafy.getbestthumb()` to fetch the best resolution thumbnail available for a video. For example:
```python
>>> import pafy

>>> v = pafy.new("wbvG5_WK5yU")
>>> v.getbestthumb()
'http://i.ytimg.com/vi/wbvG5_WK5yU/maxresdefault.jpg'

>>> v = pafy.new("pOtO21jh6vA")
>>> v.getbestthumb()
'http://i.ytimg.com/vi/pOtO21jh6vA/hqdefault.jpg'
```