### PR TITLE
fix when checking video from live stream

### DIFF
--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -46,6 +46,10 @@ class YtdlPafy(BasePafy):
             self.callback("Fetched video info")
 
         self._title = self._ydl_info['title']
+
+        if self._ydl_info.get('entries'):
+            self._ydl_info = self._ydl_info['entries'][0]
+
         self._author = self._ydl_info['uploader']
         self._rating = self._ydl_info['average_rating']
         self._length = self._ydl_info['duration']


### PR DESCRIPTION
Videos from live streams are not always working (this is an assumption), for example, with the develop branch, `pip3 install --user youtube-dl` and the following video https://www.youtube.com/watch?v=vsDknmK30C0, the following stacktrace is observed:
```
>>> import pafy
>>> pafy.new("https://www.youtube.com/watch?v=vsDknmK30C0")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/laxa/Documents/pafy/pafy/pafy.py", line 124, in new
    return Pafy(url, basic, gdata, size, callback, ydl_opts=ydl_opts)
  File "/home/laxa/Documents/pafy/pafy/backend_youtube_dl.py", line 31, in __init__
    super(YtdlPafy, self).__init__(*args, **kwargs)
  File "/home/laxa/Documents/pafy/pafy/backend_shared.py", line 97, in __init__
    self._fetch_basic()
  File "/home/laxa/Documents/pafy/pafy/backend_youtube_dl.py", line 53, in _fetch_basic
    self._author = self._ydl_info['uploader']
KeyError: 'uploader'
```

The following PR resolves this issue, the video is then playable inside `mpsyt`. This partially solves issue #193 