### PR TITLE
Add support for album playlists with OL prefix

### DIFF
--- a/pafy/playlist.py
+++ b/pafy/playlist.py
@@ -20,7 +20,8 @@ def extract_playlist_id(playlist_url):
     # Normal playlists start with PL, Mixes start with RD + first video ID,
     # Liked videos start with LL, Uploads start with UU,
     # Favorites lists start with FL
-    idregx = re.compile(r'((?:RD|PL|LL|UU|FL)[-_0-9a-zA-Z]+)$')
+    # Album playlists start with OL
+    idregx = re.compile(r'((?:RD|PL|LL|UU|FL|OL)[-_0-9a-zA-Z]+)$')
 
     playlist_id = None
     if idregx.match(playlist_url):


### PR DESCRIPTION
Album playlists, such as https://www.youtube.com/playlist?list=OLAK5uy_llf_BmriM2TWt0gsrdcnUH_qmGg3--1pU, use an OL prefix, which is not recognized by pafy.