### PR TITLE
Update audiostream URL to work with youtube-dl>2019.3.1

### DIFF
--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -115,7 +115,7 @@ class YtdlStream(BaseStream):
 
         self._extension = info['ext']
         self._notes = info.get('format_note') or ''
-        self._url = info.get('url')
+        self._url = info.get('fragment_base_url')
 
         self._info = info
 


### PR DESCRIPTION
Fixes #227.

Seems like youtube-dl>2019.3.1 exposes the audio content URL in `fragment_base_url` instead of the previously used `url` key.