### PR TITLE
Revert "Update audiostream URL to work with youtube-dl>2019.3.1"

### DIFF
--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -115,7 +115,7 @@ class YtdlStream(BaseStream):
 
         self._extension = info['ext']
         self._notes = info.get('format_note') or ''
-        self._url = info.get('fragment_base_url')
+        self._url = info.get('url')
 
         self._info = info
 


### PR DESCRIPTION
Reverts mps-youtube/pafy#230

After merging this and testing it further I've realised that this change breaks some downloads for me.

```
In [1]: import pafy                                                                                                  

In [2]: vid = pafy.new("www.youtube.com/watch?v=EuFfmnu34rs")                                                        

In [3]: vid.streams[1].download(filepath='/tmp/test3.webm')                                                          
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-0cba043e8477> in <module>
----> 1 vid.streams[1].download(filepath='/tmp/test3.webm')

~/prog/python/pafy/pafy/backend_youtube_dl.py in download(self, filepath, quiet, progress, callback, meta, remux_audio)
    179         infodict = {'url': self.url}
    180 
--> 181         downloader.download(filepath, infodict)
    182         print()
    183 

/usr/lib/python3.7/site-packages/youtube_dl/downloader/common.py in download(self, filename, info_dict)
    362             time.sleep(sleep_interval)
    363 
--> 364         return self.real_download(filename, info_dict)
    365 
    366     def real_download(self, filename, info_dict):

/usr/lib/python3.7/site-packages/youtube_dl/downloader/http.py in real_download(self, filename, info_dict)
    339         while count <= retries:
    340             try:
--> 341                 establish_connection()
    342                 return download()
    343             except RetryDownload as e:

/usr/lib/python3.7/site-packages/youtube_dl/downloader/http.py in establish_connection()
    102             has_range = range_start is not None
    103             ctx.has_range = has_range
--> 104             request = sanitized_Request(url, None, headers)
    105             if has_range:
    106                 set_range(request, range_start, range_end)

/usr/lib/python3.7/site-packages/youtube_dl/utils.py in sanitized_Request(url, *args, **kwargs)
    559 
    560 def sanitized_Request(url, *args, **kwargs):
--> 561     return compat_urllib_request.Request(sanitize_url(url), *args, **kwargs)
    562 
    563 

/usr/lib/python3.7/site-packages/youtube_dl/utils.py in sanitize_url(url)
    543     # Prepend protocol-less URLs with `http:` scheme in order to mitigate
    544     # the number of unwanted failures due to missing protocol
--> 545     if url.startswith('//'):
    546         return 'http:%s' % url
    547     # Fix some common typos seen so far

AttributeError: 'NoneType' object has no attribute 'startswith'
```
Apologies for the hassle. I don't have the time to fully debug this right now but will take a look shortly and hopefully edit with a fix.