### PR TITLE
Fixes #227

### DIFF
--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -116,6 +116,8 @@ class YtdlStream(BaseStream):
         self._extension = info['ext']
         self._notes = info.get('format_note') or ''
         self._url = info.get('url')
+        if self._url.startswith("https://manifest.googlevideo.com"):
+            self._url = info.get('fragment_base_url', self._url)
 
         self._info = info
 


### PR DESCRIPTION
Gets the stream's url from the `fragment_base_url` key only if the `url` key has the xml info.
I'm using it for almost a month now and I haven't found a not working link yet.