### PR TITLE
Release v0.5.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+21 November 2019
+Version 0.5.5
+
+[Performance] Fix download throttling for youtube-dl (@vn-ki) (#203)
+[Feature] - Support passing custom filenames to ytdl command-line tool
+    (@inspectorG4dget) (#208)
+[Update] - Pass ydl_opts as keyword argument instead of positional argument
+    (@ryin1) (#210)
+[Bugfix] - Fix crash when no view_count is returned (@dokime7) (#220)
+[Update] - Set shebang to force to Python 3 instead of system version of
+    Python (@pirate486743186) (#224)
+[Update] - Support OL playlist urls (@lopsided98) (#226)
+[BugFix] - Prefer HTTPS by default otherwise some video URLs fail (@ritiek) (#235)
+
+-------------------------------------------------------------------------------
+
 11 February 2018
 Version 0.5.4
 

--- a/pafy/__init__.py
+++ b/pafy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 __author__ = "np1"
 __license__ = "LGPLv3"
 


### PR DESCRIPTION
Someone needs to approve this first so it can be merged, and also so that I can go ahead and publish v0.5.5 on PyPI and as a GitHub release as well (see #221).

Commits made to the develop branch since v0.5.4 can be found at https://github.com/mps-youtube/pafy/compare/v0.5.4...develop.