### PR TITLE
bugfix - YtdlStream.download() not returning filepath

### DIFF
--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -185,6 +185,8 @@ class YtdlStream(BaseStream):
             subprocess.run(['mv', filepath, filepath + '.temp'])
             remux(filepath + '.temp', filepath, quiet=quiet, muxer=remux_audio)
 
+        return filepath
+
 
 class ydl:
     def urlopen(self, url):


### PR DESCRIPTION
bugfix: YtdlStream.download forgets to return the filepath as specified in the documentation and as in the base class.