### PR TITLE
Repo has migrated from np1 to mps-youtube

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
     :target: https://pypi.python.org/pypi/pafy
 .. image:: https://img.shields.io/pypi/dm/Pafy.svg
     :target: https://pypi.python.org/pypi/pafy
-.. image:: https://img.shields.io/coveralls/np1/pafy/develop.svg
-    :target: https://coveralls.io/r/np1/pafy?branch=develop
+.. image:: https://img.shields.io/coveralls/mps-youtube/pafy/develop.svg
+    :target: https://coveralls.io/r/mps-youtube/pafy?branch=develop
 .. image:: https://landscape.io/github/mps-youtube/pafy/develop/landscape.svg
     :target: https://landscape.io/github/mps-youtube/pafy/develop
     :alt: Code Health

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,12 +4,9 @@ Pafy Documentation
 
 This is the documentation for pafy - a Python library to download YouTube content and retrieve metadata
 
-A quick start intro with usage examples is available in the `README <http://github.com/np1/pafy/blob/master/README.rst>`_
+A quick start intro with usage examples is available in the `README <http://github.com/mps-youtube/pafy/blob/develop/README.rst>`_
 
-Development / Source code / Bug reporting: `github.com/np1/pafy
-<https://github.com/np1/pafy/>`_
-
-Homepage: `np1.github.io/pafy <http://np1.github.io/pafy/>`_
+Development / Source code / Bug reporting: `github.com/mps-youtube/pafy <https://github.com/mps-youtube/pafy/>`_
 
 API Keys
 ========

--- a/pafy/pafy.py
+++ b/pafy/pafy.py
@@ -5,7 +5,7 @@ pafy.py.
 
 Python library to download YouTube content and retrieve metadata
 
-https://github.com/np1/pafy
+https://github.com/mps-youtube/pafy
 
 Copyright (C)  2013-2014 np1
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 """ setup.py for pafy.
 
-https://np1.github.com/np1/pafy
+https://github.com/mps-youtube/pafy
 
 python setup.py sdist bdist_wheel
 
@@ -21,8 +21,8 @@ setup(
     keywords=["pafy", "API", "YouTube", "youtube", "download", "video"],
     author="np1",
     author_email="np1nagev@gmail.com",
-    url="http://np1.github.io/pafy/",
-    download_url="https://github.com/np1/pafy/tarball/master",
+    url="https://github.com/mps-youtube/pafy/",
+    download_url="https://github.com/mps-youtube/pafy/tags",
     extras_require={
         'youtube-dl-backend': ["youtube-dl"],
         },


### PR DESCRIPTION
The previous homepage (http://np1.github.io/np1/pafy) could not be found
anymore.