### PR TITLE
Consistent print statement for Python 2 & 3

### DIFF
--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -179,7 +179,7 @@ class YtdlStream(BaseStream):
         infodict = {'url': self.url}
 
         downloader.download(filepath, infodict)
-        print()
+        print("")
 
         if remux_audio and self.mediatype == "audio":
             subprocess.run(['mv', filepath, filepath + '.temp'])


### PR DESCRIPTION
`print` in Python 2 is a keyword and in Python 3 is a function.

That means the statement
```
>>> print()
```
would show different behaviour depending on the Python version used.
That is, printing a blank line (which is what we want) in Python 3
while printing "()" in Python 2.

Fixes #248.