### PR TITLE
Use Python built-in `os.rename` to move files

### DIFF
--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -2,7 +2,6 @@ import sys
 import time
 import logging
 import os
-import subprocess
 
 if sys.version_info[:2] >= (3, 0):
     # pylint: disable=E0611,F0401,I0011
@@ -182,7 +181,7 @@ class YtdlStream(BaseStream):
         print()
 
         if remux_audio and self.mediatype == "audio":
-            subprocess.run(['mv', filepath, filepath + '.temp'])
+            os.rename(filepath, filepath + '.temp')
             remux(filepath + '.temp', filepath, quiet=quiet, muxer=remux_audio)
 
         return filepath


### PR DESCRIPTION
Using subprocess to call `mv` assumes that the shell command `mv` exists
and its operation is to move files. This move operation would fail if
`mv` doesn't exist or has been modified to perform some other operation.

Using Python's built-in `os.rename` is more reliable.