### PR TITLE
changed to receive any 11 characters

### DIFF
--- a/pafy/backend_shared.py
+++ b/pafy/backend_shared.py
@@ -29,7 +29,7 @@ dbg = logging.debug
 
 def extract_video_id(url):
     """ Extract the video id from a url, return video id as str. """
-    idregx = re.compile(r'[\w-]{11}$')
+    idregx = re.compile(r'.{11}$')
     url = str(url).strip()
 
     if idregx.match(url):


### PR DESCRIPTION
Youtube now uses 11 characters such as http://youtu.be/5K65zEzuL-Q
Previously it receives one word( with 11 characters. [\w-] equivalent to [a-zA-Z0-9_]
Changed to get any 11 characters (including special characters).