### PR TITLE
Bugfix - _fetch_basic crashes if thumbnail doesnt exist

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ hugovk
 ids1024
 williamroot
 trygveaa
+landonrepp

--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -53,7 +53,7 @@ class YtdlPafy(BasePafy):
         self._dislikes = self._ydl_info['dislike_count']
         self._username = self._ydl_info['uploader_id']
         self._category = self._ydl_info['categories'][0] if self._ydl_info['categories'] else ''
-        self._bestthumb = self._ydl_info['thumbnails'][0]['url']
+        self._bestthumb = self._ydl_info['thumbnails'][0]['url'] if self._ydl_info.get('thumbnails',None) else ''
         self._bigthumb = g.urls['bigthumb'] % self.videoid
         self._bigthumbhd = g.urls['bigthumbhd'] % self.videoid
         self.expiry = time.time() + g.lifespan


### PR DESCRIPTION
a proposed fix for issue #268. This should stop pafy from crashing if ytdl doesn't find a thumbnail.