### PR TITLE
Get Subtitles for YouTube videos

### DIFF
--- a/pafy/backend_internal.py
+++ b/pafy/backend_internal.py
@@ -68,6 +68,7 @@ class InternPafy(BasePafy):
         self._keywords = _get_lst('keywords', "").split(',')
         self._bigthumb = _get_lst('iurlsd', "")
         self._bigthumbhd = _get_lst('iurlsdmaxres', "")
+        self._subtitles = {}  # no subtitles with the internal backend
         self.ciphertag = _get_lst("use_cipher_signature") == "True"
         self.sm = _extract_smap(g.UEFSM, allinfo, True)
         self.asm = _extract_smap(g.AF, allinfo, True)

--- a/pafy/backend_shared.py
+++ b/pafy/backend_shared.py
@@ -326,6 +326,14 @@ class BasePafy(object):
         return self._dislikes
 
     @property
+    def subtitles(self):
+        """ The subtitles of the video. Returns dict. """
+        if not self._subtitles:
+            self._fetch_basic()
+
+        return self._subtitles
+
+    @property
     def mix(self):
         """ The playlist for the related YouTube mix. Returns a Playlist object. """
         if self._mix_pl is None:

--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -54,6 +54,7 @@ class YtdlPafy(BasePafy):
         self._username = self._ydl_info['uploader_id']
         self._category = self._ydl_info['categories'][0] if self._ydl_info['categories'] else ''
         self._bestthumb = self._ydl_info['thumbnails'][0]['url']
+        self._subtitles = self._ydl_info.get('subtitles', {})
         self._bigthumb = g.urls['bigthumb'] % self.videoid
         self._bigthumbhd = g.urls['bigthumbhd'] % self.videoid
         self.expiry = time.time() + g.lifespan

--- a/pafy/g.py
+++ b/pafy/g.py
@@ -27,7 +27,8 @@ lifespan = 60 * 60 * 5  # 5 hours
 opener = build_opener()
 opener.addheaders = [('User-Agent', user_agent)]
 cache = {}
-def_ydl_opts = {'quiet': True, 'prefer_insecure': False, 'no_warnings': True}
+def_ydl_opts = {'quiet': True, 'prefer_insecure': False,
+                'no_warnings': True, "writesubtitles": True}
 
 # The following are specific to the internal backend
 UEFSM = 'url_encoded_fmt_stream_map'


### PR DESCRIPTION
Since the only working backend is the `youtube_dl` and we use it to take most of the info, we can add subtitles support without any added cost, using the same `ydl.extract_info` call.