### PR TITLE
Skip dislike_count to avoid error

### DIFF
--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -50,7 +50,7 @@ class YtdlPafy(BasePafy):
         self._length = self._ydl_info['duration']
         self._viewcount = self._ydl_info['view_count']
         self._likes = self._ydl_info.get('like_count', 0)
-        self._dislikes = self._ydl_info.get('dislike_count', 0)
+        # self._dislikes = self._ydl_info.get('dislike_count', 0)
         self._username = self._ydl_info['uploader_id']
         self._category = self._ydl_info['categories'][0] if self._ydl_info['categories'] else ''
         self._bestthumb = self._ydl_info['thumbnails'][0]['url']


### PR DESCRIPTION
Youtube stops displaying the dislike count, thus an exception will be thrown out when a new stream is created.
This minus revision just make it work, if anyone is still using this repo.