### PR TITLE
KeyError: 'average_rating' fixed

### DIFF
--- a/pafy/backend_youtube_dl.py
+++ b/pafy/backend_youtube_dl.py
@@ -46,7 +46,7 @@ class YtdlPafy(BasePafy):
 
         self._title = self._ydl_info['title']
         self._author = self._ydl_info['uploader']
-        self._rating = self._ydl_info['average_rating']
+        self._rating = self._ydl_info.get('average_rating',0)
         self._length = self._ydl_info['duration']
         self._viewcount = self._ydl_info['view_count']
         self._likes = self._ydl_info.get('like_count', 0)


### PR DESCRIPTION
Line 49 of the "pafy/backend_youtube_dl.py" file changed from "self._rating = self._ydl_info['average_rating']" to "self._rating = self._ydl_info.get('average_rating',0)"